### PR TITLE
Avoid warning for NULL search results.

### DIFF
--- a/Querying_JWST_in_astroquery.ipynb
+++ b/Querying_JWST_in_astroquery.ipynb
@@ -183,6 +183,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs = Observations.query_criteria(\n",
+    "        target_name=\"Io*\",\n",
+    "        obs_collection=\"JWST\"\n",
+    "        )\n",
+    "    \n",
+    "display_results(obs)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -206,20 +220,6 @@
     "        dataproduct_type=\"image\",\n",
     "        obs_collection=\"JWST\"\n",
     "        )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "obs = Observations.query_criteria(\n",
-    "        target_name=\"Io*\",\n",
-    "        obs_collection=\"JWST\"\n",
-    "        )\n",
-    "    \n",
-    "display_results(obs)"
    ]
   },
   {
@@ -354,7 +354,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "With your targets in memory, you may query on them using the same ``astroquery`` functions as described above.  For example, query by source identifier using the list of target names to get the count of the number of results before performing the query for observations in MAST.\n",
+    "With your targets in memory, you may query on them using the same ``astroquery`` functions as described above.  For example, query by source identifier using of target names to get the count of the number of results before performing the query for observations in MAST.\n",
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",
     "\n",
@@ -375,15 +375,16 @@
     "target_names = {name:0 for name in targets['target_name']}\n",
     "\n",
     "# get the counts of each target\n",
-    "search_radius = '300s'\n",
+    "search_radius = '30s'\n",
     "for t,n in target_names.items():\n",
     "    target_names[t] = Observations.query_criteria_count(\n",
     "            objectname=t, \n",
     "            radius='{}'.format(search_radius), \n",
+    "            dataproduct_type=\"spectrum\",\n",
     "            obs_collection='JWST'\n",
     "            )\n",
     "\n",
-    "target_names"
+    "targets['N_obs'] = list(target_names.values())"
    ]
   },
   {
@@ -399,15 +400,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "targets['ra_deg'] = [Angle(x+' hours').degree for x in tb['RA']]\n",
-    "targets['dec_deg'] = [Angle(x+' degree').degree for x in tb['DEC']]"
+    "targets['ra_deg'] = [Angle(x+' hours').degree for x in targets['RA']]\n",
+    "targets['dec_deg'] = [Angle(x+' degree').degree for x in targets['DEC']]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This example will use a constant search window (i.e., spatial extent on the sky) of 0.1&deg;, but it would be simple to customize the search area per target. This search will be for <b><i>imaging data products only</i></b>, to illustrate the case where spectra are not important for identifying duplications. Each target search returns a separate object table, so we concatenate them for display. "
+    "This example will use a constant search window (i.e., spatial extent on the sky) of 0.1&deg;, but it would be simple to customize the search area per target. This search will be for <b><i>spectrum data products only</i></b>, to illustrate the case where images are not important for identifying duplications. Each target search returns a separate object table, so we concatenate them for display. Note: we only search for targets where the count of observations is greater than zero to save a little time."
    ]
   },
   {
@@ -419,15 +420,16 @@
     "window = 0.05\n",
     "obs_list = []\n",
     "for r in targets:\n",
-    "    ra_range = [r['ra_deg']-window, r['ra_deg']+window]\n",
-    "    dec_range = [r['dec_deg']-window, r['dec_deg']+window]\n",
-    "    obs = Observations.query_criteria(\n",
-    "        s_ra=ra_range,\n",
-    "        s_dec=dec_range,\n",
-    "        dataproduct_type=\"image\",\n",
-    "        obs_collection=\"JWST\"\n",
-    "        )\n",
-    "    obs_list.append(obs)\n",
+    "    if r['N_obs'] > 0:\n",
+    "        ra_range = [r['ra_deg']-window, r['ra_deg']+window]\n",
+    "        dec_range = [r['dec_deg']-window, r['dec_deg']+window]\n",
+    "        obs = Observations.query_criteria(\n",
+    "            s_ra=ra_range,\n",
+    "            s_dec=dec_range,\n",
+    "            dataproduct_type=\"spectrum\",\n",
+    "            obs_collection=\"JWST\"\n",
+    "            )\n",
+    "        obs_list.append(obs)\n",
     "    \n",
     "target_matches = table.vstack(obs_list)\n",
     "display_results(target_matches)"
@@ -455,13 +457,6 @@
     "This notebook was developed by Archive Sciences Branch staff, chiefly Susan Mullally and Dick Shaw. For support, please contact the Archive HelpDesk at archive@stsci.edu, or through the [JWST HelpDesk Portal](https://jwsthelp.stsci.edu). \n",
     "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Updated the search of targets read from a file. Saved the count of search results, and then use that to avoid searching on targets  where we already know there are no results.